### PR TITLE
Parse the Authorization bearer token in the application itself

### DIFF
--- a/notification_backend/http.py
+++ b/notification_backend/http.py
@@ -2,6 +2,7 @@ import json
 import jwt
 import boto3
 import logging
+import re
 
 
 logger = logging.getLogger("notification_backend")
@@ -30,8 +31,12 @@ def format_response(http_status_code, payload):
 
 
 def validate_jwt(token, secret):
+    token_header = re.match('^Bearer (.+)', token)
+    if not token_header:
+        logger.debug("Could not match bearer token - Authorization header probably missing")  # NOQA
+        return None
     try:
-        return jwt.decode(token, secret)
+        return jwt.decode(token_header.group(1), secret)
     except jwt.exceptions.InvalidTokenError as e:
         logger.debug("Invalid Token Error: %s" % str(e))
         return None

--- a/server.py
+++ b/server.py
@@ -3,7 +3,6 @@ import sys
 import time
 import json
 import os
-import re
 import logging
 from notification_backend.entrypoint import handler
 
@@ -95,14 +94,12 @@ class LocalNotificationBackend(BaseHTTPServer.BaseHTTPRequestHandler):
 
 
 def handle_request(payload, headers, resource_path, http_method):
-    token_header = re.match('^Bearer (.+)',
-                            headers.get("Authorization", "Bearer faketoken"))
     event = {
         "resource-path": resource_path,
         "payload": payload,
         "http-method": http_method,
         "jwt_signing_secret": "supersekr3t",
-        "bearer_token": token_header.group(1),
+        "bearer_token": headers.get("Authorization"),
         "notification_dynamodb_endpoint_url": os.environ['DYNAMODB_ENDPOINT_URL'],  # NOQA
         "notification_user_notification_dynamodb_table_name": os.environ['NOTIFICATION_USER_NOTIFICATION_DYNAMODB_TABLE_NAME'],  # NOQA
         "notification_user_notification_date_dynamodb_index_name": os.environ['NOTIFICATION_USER_NOTIFICATION_DATE_DYNAMODB_INDEX_NAME'],  # NOQA

--- a/tests/test_delete_thread.py
+++ b/tests/test_delete_thread.py
@@ -20,7 +20,7 @@ class TestDeleteThread(unittest.TestCase):
                                 algorithm='HS256')
         self.lambda_event = {
             "jwt_signing_secret": self.jwt_signing_secret,
-            "bearer_token": self.token,
+            "bearer_token": "Bearer %s" % self.token,
             "resource-path": "/notification/threads/123456",
             "payload": {
                 "data": {

--- a/tests/test_find_all_threads.py
+++ b/tests/test_find_all_threads.py
@@ -26,7 +26,7 @@ class TestFindAllThreads(unittest.TestCase):
                                 algorithm='HS256')
         self.lambda_event = {
             "jwt_signing_secret": self.jwt_signing_secret,
-            "bearer_token": self.token,
+            "bearer_token": "Bearer %s" % self.token,
             "payload": {},
             "resource-path": "/notification/threads",
             "notification_dynamodb_endpoint_url": "http://example.com",

--- a/tests/test_update_thread.py
+++ b/tests/test_update_thread.py
@@ -19,7 +19,7 @@ class TestUpdateThread(unittest.TestCase):
                                 algorithm='HS256')
         self.lambda_event = {
             "jwt_signing_secret": self.jwt_signing_secret,
-            "bearer_token": self.token,
+            "bearer_token": "Bearer %s" % self.token,
             "resource-path": "/notification/threads/123456",
             "payload": {
                 "data": {


### PR DESCRIPTION
Without this in place, the onus was on the caller to supply the Authorization header without the prefixed 'Bearer ' string. This doesn't make sense so let's try something standard instead!
