### PR TITLE
Utilize API Gateway's `$input.params(x)` feature to handle the `thread_id` and `from` query string

### DIFF
--- a/notification_backend/entrypoint.py
+++ b/notification_backend/entrypoint.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from notification_backend.notification_threads import NotificationThreads
 from notification_backend.http import format_response
 from notification_backend.http import format_error_payload
@@ -15,28 +14,24 @@ def handler(event, context):
 
     resource_path = event.get('resource-path')
     http_method = event.get('http-method')
-    thread_id_path = re.match('^/notification/threads/([0-9]+)$',
-                              resource_path)
-    thread_params_path = re.match('^/notification/threads(\?.+)?$',
-                                  resource_path)
 
-    if http_method == "GET" and thread_id_path:
-        logger.debug("Getting info about thread: %s" % thread_id_path.group(1))
-        t = NotificationThreads(event)
-        return t.process_thread_event("find_thread")
-
-    elif http_method == "GET" and thread_params_path:
+    if http_method == "GET" and resource_path == "/notification/threads":
         logger.debug("Getting a list of all threads")
         t = NotificationThreads(event)
         return t.process_thread_event("find_all_threads")
 
-    elif http_method == "PATCH" and thread_id_path:
-        logger.debug("Updating thread: %s" % thread_id_path.group(1))
+    elif http_method == "GET" and resource_path == "/notification/threads/{thread-id}":  # NOQA
+        logger.debug("Getting info about thread: %s" % event.get('threadid'))
+        t = NotificationThreads(event)
+        return t.process_thread_event("find_thread")
+
+    elif http_method == "PATCH" and resource_path == "/notification/threads/{thread-id}":  # NOQA
+        logger.debug("Updating thread: %s" % event.get('threadid'))
         t = NotificationThreads(event)
         return t.process_thread_event("update_thread")
 
-    elif http_method == "DELETE" and thread_id_path:
-        logger.debug("Deleting thread: %s" % thread_id_path.group(1))
+    elif http_method == "DELETE" and resource_path == "/notification/threads/{thread-id}":  # NOQA
+        logger.debug("Deleting thread: %s" % event.get('threadid'))
         t = NotificationThreads(event)
         return t.process_thread_event("delete_thread")
 

--- a/tests/test_delete_thread.py
+++ b/tests/test_delete_thread.py
@@ -21,7 +21,8 @@ class TestDeleteThread(unittest.TestCase):
         self.lambda_event = {
             "jwt_signing_secret": self.jwt_signing_secret,
             "bearer_token": "Bearer %s" % self.token,
-            "resource-path": "/notification/threads/123456",
+            "resource-path": "/notification/threads/{thread-id}",
+            "threadid": "123456",
             "payload": {
                 "data": {
                     "id": 123456,

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -41,11 +41,12 @@ class TestEntrypoint(unittest.TestCase):
 
     def test_find_thread_endpoint(self):
         event = {
-            "resource-path": "/notification/threads/12345",
-            "http-method": "GET"
+            "resource-path": "/notification/threads/{thread-id}",
+            "http-method": "GET",
+            "threadid": "12345"
         }
         handler(event, {})
-        self.assertTrue(call({'resource-path': '/notification/threads/12345', 'http-method': 'GET'}) in self.mock_notif_threads.mock_calls)  # NOQA
+        self.assertTrue(call(event) in self.mock_notif_threads.mock_calls)
         self.assertTrue(call().process_thread_event('find_thread') in self.mock_notif_threads.mock_calls)  # NOQA
         self.assertEqual(len(self.mock_notif_threads.mock_calls), 2)
 
@@ -55,36 +56,39 @@ class TestEntrypoint(unittest.TestCase):
             "http-method": "GET"
         }
         handler(event, {})
-        self.assertTrue(call({'resource-path': '/notification/threads', 'http-method': 'GET'}) in self.mock_notif_threads.mock_calls)  # NOQA
+        self.assertTrue(call(event) in self.mock_notif_threads.mock_calls)
         self.assertTrue(call().process_thread_event('find_all_threads') in self.mock_notif_threads.mock_calls)  # NOQA
         self.assertEqual(len(self.mock_notif_threads.mock_calls), 2)
 
     def test_find_all_threads_endpoint_qs(self):
         event = {
-            "resource-path": "/notification/threads?hello=hi",
-            "http-method": "GET"
+            "resource-path": "/notification/threads",
+            "http-method": "GET",
+            "qs_from": "123",
         }
         handler(event, {})
-        self.assertTrue(call({'resource-path': '/notification/threads?hello=hi', 'http-method': 'GET'}) in self.mock_notif_threads.mock_calls)  # NOQA
+        self.assertTrue(call(event) in self.mock_notif_threads.mock_calls)
         self.assertTrue(call().process_thread_event('find_all_threads') in self.mock_notif_threads.mock_calls)  # NOQA
         self.assertEqual(len(self.mock_notif_threads.mock_calls), 2)
 
     def test_update_thread_endpoint_qs(self):
         event = {
-            "resource-path": "/notification/threads/12345",
-            "http-method": "PATCH"
+            "resource-path": "/notification/threads/{thread-id}",
+            "http-method": "PATCH",
+            "threadid": "12345"
         }
         handler(event, {})
-        self.assertTrue(call({'resource-path': '/notification/threads/12345', 'http-method': 'PATCH'}) in self.mock_notif_threads.mock_calls)  # NOQA
+        self.assertTrue(call(event) in self.mock_notif_threads.mock_calls)
         self.assertTrue(call().process_thread_event('update_thread') in self.mock_notif_threads.mock_calls)  # NOQA
         self.assertEqual(len(self.mock_notif_threads.mock_calls), 2)
 
     def test_delete_thread_endpoint(self):
         event = {
-            "resource-path": "/notification/threads/12345",
-            "http-method": "DELETE"
+            "resource-path": "/notification/threads/{thread-id}",
+            "http-method": "DELETE",
+            "threadid": "12345"
         }
         handler(event, {})
-        self.assertTrue(call({'resource-path': '/notification/threads/12345', 'http-method': 'DELETE'}) in self.mock_notif_threads.mock_calls)  # NOQA
+        self.assertTrue(call(event) in self.mock_notif_threads.mock_calls)
         self.assertTrue(call().process_thread_event('delete_thread') in self.mock_notif_threads.mock_calls)  # NOQA
         self.assertEqual(len(self.mock_notif_threads.mock_calls), 2)

--- a/tests/test_find_all_threads.py
+++ b/tests/test_find_all_threads.py
@@ -50,7 +50,7 @@ class TestFindAllThreads(unittest.TestCase):
         }]
 
     def test_invalid_from_date(self):
-        self.lambda_event['resource-path'] = "/notification/threads?from=faketest"  # NOQA
+        self.lambda_event['qs_from'] = "faketest"
         t = NotificationThreads(self.lambda_event)
         with self.assertRaises(TypeError) as cm:
             t.process_thread_event("find_all_threads")
@@ -81,7 +81,7 @@ class TestFindAllThreads(unittest.TestCase):
         self.assertTrue(self.mock_db_results.mock_calls > 0)
 
     def test_out_of_range_form_date(self):
-        self.lambda_event['resource-path'] = "/notification/threads?from=0"
+        self.lambda_event['qs_from'] = "0"
         expected_from_date = self.mock_time.return_value - self.backlog_time_limit  # NOQA
         t = NotificationThreads(self.lambda_event)
         t.process_thread_event("find_all_threads")

--- a/tests/test_find_thread.py
+++ b/tests/test_find_thread.py
@@ -26,7 +26,8 @@ class TestFindThread(unittest.TestCase):
             "jwt_signing_secret": self.jwt_signing_secret,
             "bearer_token": "Bearer %s" % self.token,
             "payload": {},
-            "resource-path": "/notification/threads/12345678",
+            "resource-path": "/notification/threads/{thread-id}",
+            "threadid": "12345678",
             "notification_dynamodb_endpoint_url": "http://example.com",
             "notification_user_notification_dynamodb_table_name": "fakethreads"
         }

--- a/tests/test_update_thread.py
+++ b/tests/test_update_thread.py
@@ -20,7 +20,8 @@ class TestUpdateThread(unittest.TestCase):
         self.lambda_event = {
             "jwt_signing_secret": self.jwt_signing_secret,
             "bearer_token": "Bearer %s" % self.token,
-            "resource-path": "/notification/threads/123456",
+            "resource-path": "/notification/threads/{thread-id}",
+            "threadid": "123456",
             "payload": {
                 "data": {
                     "id": 123456,


### PR DESCRIPTION
More info available at: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#input-variable-reference
